### PR TITLE
feat: allow view model access

### DIFF
--- a/xUnitRevitRunner/xUnitRevitRunnerShared/Runner.cs
+++ b/xUnitRevitRunner/xUnitRevitRunnerShared/Runner.cs
@@ -25,8 +25,6 @@ namespace xUnitRevit
         var queue = new List<Action>();
         var eventHandler = ExternalEvent.Create(new ExternalEventHandler(queue));
 
-        xru.Initialize(uiapp, SynchronizationContext.Current, eventHandler, queue);
-
         var main = new MainWindow
         {
           Title = "xUnit Revit Runner by Speckle",
@@ -35,7 +33,10 @@ namespace xUnitRevit
 
         //pre-load asssemblies, if you're a lazy developer
         if (main.DataContext is MainViewModel mainViewModel)
+        {
+          xru.Initialize(uiapp, SynchronizationContext.Current, eventHandler, queue, mainViewModel);
           mainViewModel.StartupAssemblies = Config.StartupAssemblies.ToList();
+        }
         main.Show();
       }
       catch

--- a/xUnitRevitUtils/xUnitRevitUtils2019/xUnitRevitUtils2019.csproj
+++ b/xUnitRevitUtils/xUnitRevitUtils2019/xUnitRevitUtils2019.csproj
@@ -8,7 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="ModPlus.Revit.API.2019" Version="4.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\speckle.xunit.runner.wpf\speckle.xunit.runner.wpf\speckle.xunit.runner.wpf.csproj" />
   </ItemGroup>
 
 </Project>

--- a/xUnitRevitUtils/xUnitRevitUtils2020/xUnitRevitUtils2020.csproj
+++ b/xUnitRevitUtils/xUnitRevitUtils2020/xUnitRevitUtils2020.csproj
@@ -9,7 +9,11 @@
 
   <ItemGroup>
     <PackageReference Include="ModPlus.Revit.API.2020" Version="4.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\speckle.xunit.runner.wpf\speckle.xunit.runner.wpf\speckle.xunit.runner.wpf.csproj" />
   </ItemGroup>
 
 </Project>

--- a/xUnitRevitUtils/xUnitRevitUtils2021/xUnitRevitUtils2021.csproj
+++ b/xUnitRevitUtils/xUnitRevitUtils2021/xUnitRevitUtils2021.csproj
@@ -12,4 +12,9 @@
     <PackageReference Include="xunit" Version="2.4.2" />
   </ItemGroup>
 
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\speckle.xunit.runner.wpf\speckle.xunit.runner.wpf\speckle.xunit.runner.wpf.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/xUnitRevitUtils/xUnitRevitUtils2022/xUnitRevitUtils2022.csproj
+++ b/xUnitRevitUtils/xUnitRevitUtils2022/xUnitRevitUtils2022.csproj
@@ -8,10 +8,14 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Speckle.Revit.API" Version="2022.0.2.1" >
+    <PackageReference Include="Speckle.Revit.API" Version="2022.0.2.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.2" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\speckle.xunit.runner.wpf\speckle.xunit.runner.wpf\speckle.xunit.runner.wpf.csproj" />
   </ItemGroup>
 
 </Project>

--- a/xUnitRevitUtils/xUnitRevitUtils2023/xUnitRevitUtils2023.csproj
+++ b/xUnitRevitUtils/xUnitRevitUtils2023/xUnitRevitUtils2023.csproj
@@ -14,4 +14,9 @@
     <PackageReference Include="xunit" Version="2.4.2" />
   </ItemGroup>
 
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\speckle.xunit.runner.wpf\speckle.xunit.runner.wpf\speckle.xunit.runner.wpf.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/xUnitRevitUtils/xUnitRevitUtilsShared/xru.cs
+++ b/xUnitRevitUtils/xUnitRevitUtilsShared/xru.cs
@@ -1,6 +1,7 @@
 ﻿using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using Xunit;
+using Xunit.Runner.Wpf.ViewModel;
 
 namespace xUnitRevitUtils
 {
@@ -13,12 +14,21 @@ namespace xUnitRevitUtils
     private static IList<Action> Queue { get; set; }
     private static ExternalEvent EventHandler { get; set; }
     public static SynchronizationContext UiContext { get; set; }
+    public static MainViewModel MainViewModel { get; set; }
     public static void Initialize(UIApplication uiapp, SynchronizationContext uiContext, ExternalEvent eventHandler, IList<Action> queue)
     {
       Uiapp = uiapp;
       UiContext = uiContext;
       EventHandler = eventHandler;
       Queue = queue;
+    }
+    public static void Initialize(UIApplication uiapp, SynchronizationContext uiContext, ExternalEvent eventHandler, IList<Action> queue, MainViewModel vm)
+    {
+      Uiapp = uiapp;
+      UiContext = uiContext;
+      EventHandler = eventHandler;
+      Queue = queue;
+      MainViewModel = vm;
     }
 
     #region utility methods


### PR DESCRIPTION
The unit tests are discovered and run by speckle.xunit.runner, so we should pass the view model instance via the xunitRevitUtils class so the user can access the results of their unit tests